### PR TITLE
[ch33451]Use sl-tooltip instead of paper-tooltip

### DIFF
--- a/EtoolsInfoTooltip.js
+++ b/EtoolsInfoTooltip.js
@@ -196,6 +196,7 @@ export class EtoolsInfoTooltip extends LitElement {
     this.formFieldAlign = false;
     this.customIcon = false;
     this.offset = 5;
+    this.language = window.EtoolsLanguage || 'en';
   }
 
   connectedCallback() {
@@ -209,9 +210,7 @@ export class EtoolsInfoTooltip extends LitElement {
   }
 
   _handleLanguageChange(e) {
-    setTimeout(() => {
-      this.requestUpdate();
-    }, 300);
+    this.language = e.detail.language;
   }
 
   _refreshStyles(importantWarning) {

--- a/EtoolsInfoTooltip.js
+++ b/EtoolsInfoTooltip.js
@@ -1,7 +1,5 @@
 import {LitElement, html} from 'lit-element';
-import '@polymer/paper-tooltip/paper-tooltip.js';
 import '@polymer/iron-icons/iron-icons.js';
-import '@polymer/neon-animation/neon-animations.js';
 import '@shoelace-style/shoelace/dist/components/tooltip/tooltip.js';
 
 /**
@@ -22,17 +20,6 @@ export class EtoolsInfoTooltip extends LitElement {
         }
 
         :host {
-          --tooltip-box-style: {
-            text-align: center;
-            line-height: 1.4;
-          }
-          --light-tooltip-style: {
-            -webkit-box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175);
-            -moz-box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175);
-            box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175);
-            border: 1px solid rgba(0, 0, 0, 0.15);
-          }
-
           --show-delay: 50;
 
           display: flex;
@@ -59,8 +46,12 @@ export class EtoolsInfoTooltip extends LitElement {
           --sl-tooltip-color: var(--primary-text-color, rgba(0, 0, 0, 0.87));
         }
         sl-tooltip[theme='light']::part(body) {
-          @apply --tooltip-box-style;
-          @apply --light-tooltip-style;
+          text-align: center;
+          line-height: 1.4;
+          -webkit-box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175);
+          -moz-box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175);
+          box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175);
+          border: 1px solid rgba(0, 0, 0, 0.15);
         }
 
         :host([form-field-align]) #tooltip-trigger {
@@ -92,7 +83,14 @@ export class EtoolsInfoTooltip extends LitElement {
       </style>
       <!-- element assigned to this tooltip -->
       <slot name="field"></slot>
-      <sl-tooltip id="tooltip" .trigger="${this.openOnClick ? 'click' : 'hover'}" theme="${this.theme}">
+      <sl-tooltip
+        id="tooltip"
+        .trigger="${this.openOnClick ? 'click' : 'hover'}"
+        theme="${this.theme}"
+        ?hoist="${this.hoist}"
+        .distance="${this.offset}"
+        exportparts="body"
+      >
         <div slot="content">
           <slot name="message"></slot>
         </div>
@@ -143,6 +141,11 @@ export class EtoolsInfoTooltip extends LitElement {
       },
       offset: {
         type: Number
+      },
+      hoist: {
+        type: Boolean,
+        attirbute: 'hoist',
+        reflect: true
       }
     };
   }

--- a/EtoolsInfoTooltip.js
+++ b/EtoolsInfoTooltip.js
@@ -2,6 +2,7 @@ import {LitElement, html} from 'lit-element';
 import '@polymer/paper-tooltip/paper-tooltip.js';
 import '@polymer/iron-icons/iron-icons.js';
 import '@polymer/neon-animation/neon-animations.js';
+import '@shoelace-style/shoelace/dist/components/tooltip/tooltip.js';
 
 /**
  * `etools-info-tooltip`
@@ -21,7 +22,6 @@ export class EtoolsInfoTooltip extends LitElement {
         }
 
         :host {
-          --paper-tooltip-delay-in: 0;
           --tooltip-box-style: {
             text-align: center;
             line-height: 1.4;
@@ -32,9 +32,9 @@ export class EtoolsInfoTooltip extends LitElement {
             box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175);
             border: 1px solid rgba(0, 0, 0, 0.15);
           }
-          --paper-tooltip: {
-            font-size: 12px;
-          }
+
+          --show-delay: 50;
+
           display: flex;
           flex-direction: row;
           align-items: center;
@@ -55,14 +55,12 @@ export class EtoolsInfoTooltip extends LitElement {
         }
 
         :host([theme='light']) {
-          --paper-tooltip-background: var(--primary-background-color, #ffffff);
-          --paper-tooltip-opacity: 1;
-          --paper-tooltip-text-color: var(--primary-text-color, rgba(0, 0, 0, 0.87));
-
-          --paper-tooltip: {
-            @apply --tooltip-box-style;
-            @apply --light-tooltip-style;
-          }
+          --sl-tooltip-background-color: var(--primary-background-color, #ffffff);
+          --sl-tooltip-color: var(--primary-text-color, rgba(0, 0, 0, 0.87));
+        }
+        sl-tooltip[theme='light']::part(body) {
+          @apply --tooltip-box-style;
+          @apply --light-tooltip-style;
         }
 
         :host([form-field-align]) #tooltip-trigger {
@@ -94,25 +92,16 @@ export class EtoolsInfoTooltip extends LitElement {
       </style>
       <!-- element assigned to this tooltip -->
       <slot name="field"></slot>
-      <span id="tooltip-trigger" part="eit-trigger-icon" ?hidden="${this.hideTooltip}" tabindex="0">
-        <iron-icon ?hidden="${this.customIcon}" .icon="${this.icon}"></iron-icon>
+      <sl-tooltip id="tooltip" .trigger="${this.openOnClick ? 'click' : 'hover'}" theme="${this.theme}">
+        <div slot="content">
+          <slot name="message"></slot>
+        </div>
+        <span id="tooltip-trigger" part="eit-trigger-icon" ?hidden="${this.hideTooltip}" tabindex="0">
+          <iron-icon ?hidden="${this.customIcon}" .icon="${this.icon}"></iron-icon>
 
-        <slot ?hidden="${!this.customIcon}" name="custom-icon"></slot>
-      </span>
-      <paper-tooltip
-        id="tooltip"
-        for="tooltip-trigger"
-        .position="${this.readingOrderConvertedPosition}"
-        .animationDelay="${this.animationDelay}"
-        .manualMode="${this.openOnClick}"
-        .animationConfig="${this.noAnimationConfig}"
-        animation-entry=""
-        animation-exit=""
-        .fitToVisibleBounds="${this.fitToVisibleBounds}"
-        .offset="${this.offset}"
-      >
-        <slot name="message"></slot>
-      </paper-tooltip>
+          <slot ?hidden="${!this.customIcon}" name="custom-icon"></slot>
+        </span>
+      </sl-tooltip>
     `;
   }
 
@@ -120,9 +109,6 @@ export class EtoolsInfoTooltip extends LitElement {
     return {
       position: {
         type: String
-      },
-      animationDelay: {
-        type: Number
       },
       icon: {
         type: String
@@ -142,14 +128,6 @@ export class EtoolsInfoTooltip extends LitElement {
       theme: {
         type: String
       },
-      fitToVisibleBounds: {
-        type: Boolean
-      },
-      noAnimationConfig: {
-        type: Object,
-        attribute: 'no-animation-config'
-      },
-
       openOnClick: {
         type: Boolean,
         attribute: 'open-on-click'
@@ -217,23 +195,11 @@ export class EtoolsInfoTooltip extends LitElement {
     this._openOnClick = false;
     this.formFieldAlign = false;
     this.customIcon = false;
-    this.animationDelay = 0;
-    this.fitToVisibleBounds = true;
-    this.noAnimationConfig = {};
     this.offset = 5;
   }
 
   connectedCallback() {
     super.connectedCallback();
-    setTimeout(() => {
-      const tooltipContent = this.shadowRoot.querySelector('#tooltip').shadowRoot.querySelector('#tooltip');
-      if (tooltipContent) {
-        tooltipContent.style.display = 'flex';
-        tooltipContent.style.flexDirection = 'row';
-        tooltipContent.style.textAlign = 'left';
-        tooltipContent.style.lineHeight = '16px';
-      }
-    });
     document.addEventListener('language-changed', this._handleLanguageChange.bind(this));
   }
 
@@ -266,7 +232,6 @@ export class EtoolsInfoTooltip extends LitElement {
   _addClickEventListeners() {
     const target = this.shadowRoot.querySelector('#tooltip-trigger');
     if (target) {
-      target.addEventListener('click', this._openTooltip.bind(this));
       target.addEventListener('focus', this._openTooltip.bind(this));
       // target.addEventListener('mouseenter', this._openTooltip.bind(this));
       target.addEventListener('blur', this._closeTooltip.bind(this));
@@ -277,7 +242,6 @@ export class EtoolsInfoTooltip extends LitElement {
   _removeClickEventListeners() {
     const target = this.shadowRoot.querySelector('#tooltip-trigger');
     if (target) {
-      target.removeEventListener('click', this._openTooltip);
       target.removeEventListener('focus', this._openTooltip);
       //  target.removeEventListener('mouseenter', this._openTooltip);
       target.removeEventListener('blur', this._closeTooltip);

--- a/InfoIconTooltip.js
+++ b/InfoIconTooltip.js
@@ -52,6 +52,7 @@ export class InfoIconTooltip extends LitElement {
           position: absolute;
           color: var(--primary-color);
           text-decoration: none;
+          cursor: pointer;
         }
         .elevation,
         :host(.elevation) {
@@ -101,7 +102,7 @@ export class InfoIconTooltip extends LitElement {
         .offset="${this.offset}"
       >
         <div id="etools-iit-content" part="etools-iit-content" class="elevation" elevation="1">
-          <a id="close-link" href="#" @click="${this.close}">${getTranslation(this.language, 'CLOSE')}</a>
+          <a id="close-link" @click="${this.close}">${getTranslation(this.language, 'CLOSE')}</a>
           <div class="tooltip-info gray-border">
             ${this.tooltipText ? unsafeHTML(this.tooltipText) : this.tooltipHtml}
           </div>
@@ -150,7 +151,8 @@ export class InfoIconTooltip extends LitElement {
     this.language = e.detail.language;
   }
 
-  showTooltip() {
+  showTooltip(e) {
+    e.stopImmediatePropagation();
     const tooltip = this.shadowRoot.querySelector('#tooltip');
     tooltip.show();
 
@@ -196,13 +198,35 @@ export class InfoIconTooltip extends LitElement {
     }
   }
 
+  /**
+   * stopImmediatePropagation stops dropdown openning also when this component is inside it.
+   * Conditional stopping of propagation is for timing issues, when this method executes before showTooltip.
+   */
   hideTooltip(e) {
     const path = e.composedPath() || [];
     if (path.length && path[0].id !== 'close-link' && this._isInPath(path, 'id', 'etools-iit-content')) {
+      e.stopImmediatePropagation();
       return;
     }
 
-    this.shadowRoot.querySelector('#tooltip').hide();
+    const paperTooltip = this.shadowRoot.querySelector('#tooltip');
+    if (paperTooltip._showing) {
+      paperTooltip.hide();
+      document.removeEventListener('click', this._tooltipHandler);
+      if (!this.clickedOnOtherInfoIcon(path)) {
+        e.stopImmediatePropagation();
+      }
+    }
+  }
+
+  /**
+   * Avoid 2 clicks needed to open a second info tooltip
+   */
+  clickedOnOtherInfoIcon(path) {
+    if (path[0] && path[0].id == 'info-icon' && path[0].getRootNode().host != this) {
+      return true;
+    }
+    return false;
   }
 
   close(e) {

--- a/InfoIconTooltip.js
+++ b/InfoIconTooltip.js
@@ -1,6 +1,5 @@
 import {LitElement, html, css} from 'lit-element';
 import {unsafeHTML} from 'lit-html/directives/unsafe-html';
-import '@polymer/paper-tooltip';
 import '@polymer/iron-icons/iron-icons';
 import '@shoelace-style/shoelace/dist/components/tooltip/tooltip.js';
 

--- a/InfoIconTooltip.js
+++ b/InfoIconTooltip.js
@@ -104,9 +104,7 @@ export class InfoIconTooltip extends LitElement {
     this.tooltipText = '';
     this.position = 'right';
     this.offset = 14;
-    if (!this.language) {
-      this.language = 'en';
-    }
+    this.language = window.EtoolsLanguage || 'en';
   }
 
   connectedCallback() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@unicef-polymer/etools-info-tooltip",
-  "version": "4.1.10",
+  "version": "5.0.0-rc.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@unicef-polymer/etools-info-tooltip",
-  "version": "4.1.9",
+  "version": "4.1.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -185,7 +185,8 @@
     "@polymer/font-roboto": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@polymer/font-roboto/-/font-roboto-3.0.2.tgz",
-      "integrity": "sha512-tx5TauYSmzsIvmSqepUPDYbs4/Ejz2XbZ1IkD7JEGqkdNUJlh+9KU85G56Tfdk/xjEZ8zorFfN09OSwiMrIQWA=="
+      "integrity": "sha512-tx5TauYSmzsIvmSqepUPDYbs4/Ejz2XbZ1IkD7JEGqkdNUJlh+9KU85G56Tfdk/xjEZ8zorFfN09OSwiMrIQWA==",
+      "dev": true
     },
     "@polymer/gen-typescript-declarations": {
       "version": "1.6.2",
@@ -425,6 +426,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@polymer/iron-resizable-behavior/-/iron-resizable-behavior-3.0.1.tgz",
       "integrity": "sha512-FyHxRxFspVoRaeZSWpT3y0C9awomb4tXXolIJcZ7RvXhMP632V5lez+ch5G5SwK0LpnAPkg35eB0LPMFv+YMMQ==",
+      "dev": true,
       "requires": {
         "@polymer/polymer": "^3.0.0"
       }
@@ -434,14 +436,6 @@
       "resolved": "https://registry.npmjs.org/@polymer/iron-scroll-target-behavior/-/iron-scroll-target-behavior-3.0.1.tgz",
       "integrity": "sha512-xg1WanG25BIkQE8rhuReqY9zx1K5M7F+YAIYpswEp5eyDIaZ1Y3vUmVeQ3KG+hiSugzI1M752azXN7kvyhOBcQ==",
       "dev": true,
-      "requires": {
-        "@polymer/polymer": "^3.0.0"
-      }
-    },
-    "@polymer/iron-selector": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@polymer/iron-selector/-/iron-selector-3.0.1.tgz",
-      "integrity": "sha512-sBVk2uas6prW0glUe2xEJJYlvxmYzM40Au9OKbfDK2Qekou/fLKcBRyIYI39kuI8zWRaip8f3CI8qXcUHnKb1A==",
       "requires": {
         "@polymer/polymer": "^3.0.0"
       }
@@ -464,16 +458,6 @@
       "requires": {
         "@polymer/polymer": "^3.0.0",
         "marked": "~0.3.9"
-      }
-    },
-    "@polymer/neon-animation": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@polymer/neon-animation/-/neon-animation-3.0.1.tgz",
-      "integrity": "sha512-cDDc0llpVCe0ATbDS3clDthI54Bc8YwZIeTGGmBJleKOvbRTUC5+ssJmRL+VwVh+VM5FlnQlx760ppftY3uprg==",
-      "requires": {
-        "@polymer/iron-resizable-behavior": "^3.0.0-pre.26",
-        "@polymer/iron-selector": "^3.0.0-pre.26",
-        "@polymer/polymer": "^3.0.0"
       }
     },
     "@polymer/paper-behaviors": {
@@ -529,6 +513,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@polymer/paper-styles/-/paper-styles-3.0.1.tgz",
       "integrity": "sha512-y6hmObLqlCx602TQiSBKHqjwkE7xmDiFkoxdYGaNjtv4xcysOTdVJsDR/R9UHwIaxJ7gHlthMSykir1nv78++g==",
+      "dev": true,
       "requires": {
         "@polymer/font-roboto": "^3.0.1",
         "@polymer/iron-flex-layout": "^3.0.0-pre.26",
@@ -544,15 +529,6 @@
         "@polymer/iron-a11y-announcer": "^3.0.0-pre.26",
         "@polymer/iron-fit-behavior": "^3.0.0-pre.26",
         "@polymer/iron-overlay-behavior": "^3.0.0-pre.27",
-        "@polymer/polymer": "^3.0.0"
-      }
-    },
-    "@polymer/paper-tooltip": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@polymer/paper-tooltip/-/paper-tooltip-3.0.1.tgz",
-      "integrity": "sha512-yiUk09opTEnE1lK+tb501ENb+yQBi4p++Ep0eGJAHesVYKVMPNgPphVKkIizkDaU+n0SE+zXfTsRbYyOMDYXSg==",
-      "requires": {
-        "@polymer/paper-styles": "^3.0.0-pre.26",
         "@polymer/polymer": "^3.0.0"
       }
     },
@@ -1016,7 +992,7 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
     },
     "cross-spawn": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@unicef-polymer/etools-info-tooltip",
   "description": "Tooltip element associated with form elements (or any other element). An icon is used to trigger tooltip open.",
-  "version": "4.1.9",
+  "version": "4.1.10",
   "main": "index.js",
   "module": "index.js",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@unicef-polymer/etools-info-tooltip",
   "description": "Tooltip element associated with form elements (or any other element). An icon is used to trigger tooltip open.",
-  "version": "4.1.10",
+  "version": "5.0.0-rc.1",
   "main": "index.js",
   "module": "index.js",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -17,8 +17,6 @@
   },
   "dependencies": {
     "@polymer/iron-icons": "^3.0.1",
-    "@polymer/neon-animation": "^3.0.1",
-    "@polymer/paper-tooltip": "^3.0.1",
     "@polymer/polymer": "^3.4.1",
     "lit-element": "^2.5.1"
   },


### PR DESCRIPTION
Disadvantages
- text in the tooltip can not be selected by the user or focused

TODO
- remove the use of    @apply --tooltip-box-style;
          @apply --light-tooltip-style;
